### PR TITLE
Implement feature from issue number 9

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# Markdown Todo Application Configuration
+# Copy this file to .env and modify values as needed
+
+# Directory where markdown data files are stored
+# Default: ./data (relative to project root)
+DATA_DIR=./data
+
+# File encoding for reading/writing markdown files
+# Default: utf-8
+# Valid options: utf-8, utf8, ascii, utf16le, latin1
+FILE_ENCODING=utf-8
+
+# Number of spaces per indentation level for nested tasks
+# Default: 4
+# Valid range: 1-8
+INDENT_SPACES=4
+
+# Maximum character length for task content
+# Default: 500
+# Valid range: 10-10000
+MAX_CONTENT_LENGTH=500
+
+# Maximum character length for project IDs
+# Default: 100
+# Valid range: 1-500
+MAX_PROJECT_ID_LENGTH=100

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,10 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+.env.local
+.env.*.local
+!.env.example
 
 # vercel
 .vercel

--- a/__tests__/lib/markdown-updater.test.ts
+++ b/__tests__/lib/markdown-updater.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { updateTask, addTask, deleteTask, updateMarkdown, rewriteMarkdown } from '@/lib/markdown-updater';
 import { Task, Project } from '@/lib/types';
+import { resetConfig } from '@/lib/config';
 
 // Mock fs module
 jest.mock('fs');
@@ -10,6 +11,14 @@ const mockFs = fs as jest.Mocked<typeof fs>;
 describe('markdown-updater', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetConfig();
+
+    // Mock fs functions needed by config module
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.statSync.mockReturnValue({
+      isDirectory: () => true,
+    } as fs.Stats);
+    mockFs.accessSync.mockImplementation(() => {});
   });
 
   describe('updateTask', () => {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,204 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Configuration validation errors
+ */
+export class ConfigurationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ConfigurationError';
+    }
+}
+
+/**
+ * Application configuration interface
+ */
+export interface AppConfig {
+    /** Directory where markdown data files are stored */
+    dataDir: string;
+    /** File encoding for reading/writing files */
+    fileEncoding: BufferEncoding;
+    /** Number of spaces per indentation level for nested tasks */
+    indentSpaces: number;
+    /** Valid task statuses */
+    validStatuses: readonly string[];
+    /** Due date format regex pattern */
+    dueDatePattern: RegExp;
+    /** Maximum content length for tasks */
+    maxContentLength: number;
+    /** Maximum project ID length */
+    maxProjectIdLength: number;
+}
+
+/**
+ * Load and validate a single environment variable
+ */
+function getEnvVar(key: string, defaultValue: string): string {
+    return process.env[key] || defaultValue;
+}
+
+/**
+ * Load and validate a numeric environment variable
+ */
+function getNumericEnvVar(key: string, defaultValue: number, min?: number, max?: number): number {
+    const value = process.env[key];
+    if (!value) {
+        return defaultValue;
+    }
+
+    const parsed = parseInt(value, 10);
+    if (isNaN(parsed)) {
+        throw new ConfigurationError(
+            `Invalid value for ${key}: "${value}" is not a valid number`
+        );
+    }
+
+    if (min !== undefined && parsed < min) {
+        throw new ConfigurationError(
+            `Invalid value for ${key}: ${parsed} is less than minimum ${min}`
+        );
+    }
+
+    if (max !== undefined && parsed > max) {
+        throw new ConfigurationError(
+            `Invalid value for ${key}: ${parsed} is greater than maximum ${max}`
+        );
+    }
+
+    return parsed;
+}
+
+/**
+ * Validate the data directory exists and is accessible
+ */
+function validateDataDir(dataDir: string): void {
+    const resolvedPath = path.resolve(dataDir);
+
+    // Create directory if it doesn't exist
+    if (!fs.existsSync(resolvedPath)) {
+        try {
+            fs.mkdirSync(resolvedPath, { recursive: true });
+        } catch (error) {
+            throw new ConfigurationError(
+                `Failed to create data directory "${resolvedPath}": ${error instanceof Error ? error.message : 'Unknown error'}`
+            );
+        }
+    }
+
+    // Check if it's a directory
+    const stats = fs.statSync(resolvedPath);
+    if (!stats.isDirectory()) {
+        throw new ConfigurationError(
+            `DATA_DIR "${resolvedPath}" exists but is not a directory`
+        );
+    }
+
+    // Check read/write permissions
+    try {
+        fs.accessSync(resolvedPath, fs.constants.R_OK | fs.constants.W_OK);
+    } catch {
+        throw new ConfigurationError(
+            `DATA_DIR "${resolvedPath}" is not readable/writable`
+        );
+    }
+}
+
+/**
+ * Validate file encoding is supported
+ */
+function validateFileEncoding(encoding: string): BufferEncoding {
+    const validEncodings: BufferEncoding[] = [
+        'utf-8', 'utf8', 'ascii', 'utf16le', 'ucs2', 'ucs-2',
+        'base64', 'latin1', 'binary', 'hex'
+    ];
+
+    if (!validEncodings.includes(encoding as BufferEncoding)) {
+        throw new ConfigurationError(
+            `Invalid FILE_ENCODING "${encoding}". Valid options: ${validEncodings.join(', ')}`
+        );
+    }
+
+    return encoding as BufferEncoding;
+}
+
+/**
+ * Load and validate all configuration from environment variables
+ */
+function loadConfig(): AppConfig {
+    // Load raw values from environment
+    const dataDirRaw = getEnvVar('DATA_DIR', path.join(process.cwd(), 'data'));
+    const fileEncodingRaw = getEnvVar('FILE_ENCODING', 'utf-8');
+    const indentSpaces = getNumericEnvVar('INDENT_SPACES', 4, 1, 8);
+    const maxContentLength = getNumericEnvVar('MAX_CONTENT_LENGTH', 500, 10, 10000);
+    const maxProjectIdLength = getNumericEnvVar('MAX_PROJECT_ID_LENGTH', 100, 1, 500);
+
+    // Resolve and validate data directory
+    const dataDir = path.resolve(dataDirRaw);
+    validateDataDir(dataDir);
+
+    // Validate file encoding
+    const fileEncoding = validateFileEncoding(fileEncodingRaw);
+
+    return {
+        dataDir,
+        fileEncoding,
+        indentSpaces,
+        validStatuses: ['todo', 'doing', 'done'] as const,
+        dueDatePattern: /^\d{4}-\d{2}-\d{2}$/,
+        maxContentLength,
+        maxProjectIdLength,
+    };
+}
+
+// Export singleton config instance
+// Note: Config is loaded once at module initialization
+let _config: AppConfig | null = null;
+
+/**
+ * Get the application configuration
+ * Configuration is loaded and validated once on first access
+ */
+export function getConfig(): AppConfig {
+    if (!_config) {
+        _config = loadConfig();
+    }
+    return _config;
+}
+
+/**
+ * Reset configuration (useful for testing)
+ */
+export function resetConfig(): void {
+    _config = null;
+}
+
+/**
+ * Validate configuration without loading it into the singleton
+ * Useful for checking configuration before application startup
+ */
+export function validateConfig(): { valid: boolean; errors: string[] } {
+    const errors: string[] = [];
+
+    try {
+        loadConfig();
+    } catch (error) {
+        if (error instanceof ConfigurationError) {
+            errors.push(error.message);
+        } else {
+            errors.push(`Unknown configuration error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+
+    return {
+        valid: errors.length === 0,
+        errors,
+    };
+}
+
+// Export individual config values for convenience
+export const config = new Proxy({} as AppConfig, {
+    get(_, prop: keyof AppConfig) {
+        return getConfig()[prop];
+    },
+});

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -1,17 +1,18 @@
 import fs from 'fs';
 import path from 'path';
 import { Project, Task, TaskStatus } from './types';
-
-const DATA_DIR = path.join(process.cwd(), 'data');
+import { getConfig } from './config';
 
 export async function getAllProjects(): Promise<Project[]> {
-    if (!fs.existsSync(DATA_DIR)) {
+    const config = getConfig();
+
+    if (!fs.existsSync(config.dataDir)) {
         return [];
     }
-    const files = fs.readdirSync(DATA_DIR).filter((file) => file.endsWith('.md'));
+    const files = fs.readdirSync(config.dataDir).filter((file) => file.endsWith('.md'));
     return files.map((file) => {
-        const content = fs.readFileSync(path.join(DATA_DIR, file), 'utf-8');
-        return parseMarkdown(file.replace('.md', ''), content, path.join(DATA_DIR, file));
+        const content = fs.readFileSync(path.join(config.dataDir, file), config.fileEncoding);
+        return parseMarkdown(file.replace('.md', ''), content, path.join(config.dataDir, file));
     });
 }
 


### PR DESCRIPTION
- Create centralized config module (lib/config.ts) with validation
- Externalize DATA_DIR, FILE_ENCODING, INDENT_SPACES, and limit settings
- Update security.ts, markdown.ts, and markdown-updater.ts to use config
- Add .env.example template documenting all configuration options
- Update .gitignore to allow .env.example while ignoring .env files
- Update tests to properly mock fs functions for config validation

Closes #9