### PR TITLE
Implement feature from GitHub issue

### DIFF
--- a/app/api/v1/projects/[projectId]/route.ts
+++ b/app/api/v1/projects/[projectId]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAllProjects } from '@/lib/markdown';
+import { validateProjectId } from '@/lib/security';
+
+interface RouteParams {
+    params: Promise<{
+        projectId: string;
+    }>;
+}
+
+/**
+ * GET /api/v1/projects/[projectId]
+ * Returns a specific project by ID
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+    try {
+        const { projectId } = await params;
+
+        // Validate project ID
+        const projectIdValidation = validateProjectId(projectId);
+        if (!projectIdValidation.valid) {
+            return NextResponse.json(
+                { error: projectIdValidation.error },
+                { status: 400 }
+            );
+        }
+
+        const projects = await getAllProjects();
+        const project = projects.find((p) => p.id === projectId);
+
+        if (!project) {
+            return NextResponse.json(
+                { error: 'Project not found' },
+                { status: 404 }
+            );
+        }
+
+        return NextResponse.json(project);
+    } catch (error) {
+        console.error('Error reading project:', error);
+        return NextResponse.json(
+            { error: 'Failed to read project' },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/v1/projects/[projectId]/tasks/[lineNumber]/route.ts
+++ b/app/api/v1/projects/[projectId]/tasks/[lineNumber]/route.ts
@@ -1,0 +1,188 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAllProjects } from '@/lib/markdown';
+import { updateTask, deleteTask } from '@/lib/markdown-updater';
+import { TaskStatus } from '@/lib/types';
+import {
+    validateProjectId,
+    validateTaskContent,
+    validateTaskStatus,
+    validateDueDate,
+    validateLineNumber,
+    validateFilePath,
+    withFileLock,
+    sanitizeContent,
+} from '@/lib/security';
+
+interface RouteParams {
+    params: Promise<{
+        projectId: string;
+        lineNumber: string;
+    }>;
+}
+
+/**
+ * PUT /api/v1/projects/[projectId]/tasks/[lineNumber]
+ * Updates a task's properties
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+    try {
+        const { projectId, lineNumber: lineNumberStr } = await params;
+        const lineNumber = parseInt(lineNumberStr, 10);
+        const body = await request.json();
+        const { content, status, dueDate } = body;
+
+        // Validate project ID
+        const projectIdValidation = validateProjectId(projectId);
+        if (!projectIdValidation.valid) {
+            return NextResponse.json(
+                { error: projectIdValidation.error },
+                { status: 400 }
+            );
+        }
+
+        // Validate line number
+        const lineValidation = validateLineNumber(lineNumber);
+        if (!lineValidation.valid) {
+            return NextResponse.json(
+                { error: lineValidation.error },
+                { status: 400 }
+            );
+        }
+
+        // Find project
+        const projects = await getAllProjects();
+        const project = projects.find((p) => p.id === projectId);
+
+        if (!project) {
+            return NextResponse.json(
+                { error: 'Project not found' },
+                { status: 404 }
+            );
+        }
+
+        // Validate file path
+        if (!validateFilePath(project.path)) {
+            return NextResponse.json(
+                { error: 'Invalid file path' },
+                { status: 400 }
+            );
+        }
+
+        // Use file locking
+        const result = await withFileLock(project.path, async () => {
+            const updates: { content?: string; status?: TaskStatus; dueDate?: string } = {};
+
+            // Validate and prepare updates
+            if (content !== undefined) {
+                const contentValidation = validateTaskContent(content);
+                if (!contentValidation.valid) {
+                    return { error: contentValidation.error, status: 400 };
+                }
+                updates.content = sanitizeContent(content);
+            }
+
+            if (status !== undefined) {
+                const statusValidation = validateTaskStatus(status);
+                if (!statusValidation.valid) {
+                    return { error: statusValidation.error, status: 400 };
+                }
+                updates.status = status as TaskStatus;
+            }
+
+            if (dueDate !== undefined) {
+                const dueDateValidation = validateDueDate(dueDate);
+                if (!dueDateValidation.valid) {
+                    return { error: dueDateValidation.error, status: 400 };
+                }
+                updates.dueDate = dueDate;
+            }
+
+            updateTask(project.path, lineNumber, updates);
+            return null;
+        });
+
+        // Check for validation errors
+        if (result && result.error) {
+            return NextResponse.json(
+                { error: result.error },
+                { status: result.status }
+            );
+        }
+
+        // Return updated projects
+        const updatedProjects = await getAllProjects();
+        return NextResponse.json(updatedProjects);
+    } catch (error) {
+        console.error('Error updating task:', error);
+        const errorMessage = error instanceof Error ? error.message : 'Failed to update task';
+        return NextResponse.json(
+            { error: errorMessage },
+            { status: 500 }
+        );
+    }
+}
+
+/**
+ * DELETE /api/v1/projects/[projectId]/tasks/[lineNumber]
+ * Deletes a task and its subtasks
+ */
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+    try {
+        const { projectId, lineNumber: lineNumberStr } = await params;
+        const lineNumber = parseInt(lineNumberStr, 10);
+
+        // Validate project ID
+        const projectIdValidation = validateProjectId(projectId);
+        if (!projectIdValidation.valid) {
+            return NextResponse.json(
+                { error: projectIdValidation.error },
+                { status: 400 }
+            );
+        }
+
+        // Validate line number
+        const lineValidation = validateLineNumber(lineNumber);
+        if (!lineValidation.valid) {
+            return NextResponse.json(
+                { error: lineValidation.error },
+                { status: 400 }
+            );
+        }
+
+        // Find project
+        const projects = await getAllProjects();
+        const project = projects.find((p) => p.id === projectId);
+
+        if (!project) {
+            return NextResponse.json(
+                { error: 'Project not found' },
+                { status: 404 }
+            );
+        }
+
+        // Validate file path
+        if (!validateFilePath(project.path)) {
+            return NextResponse.json(
+                { error: 'Invalid file path' },
+                { status: 400 }
+            );
+        }
+
+        // Use file locking
+        await withFileLock(project.path, async () => {
+            deleteTask(project.path, lineNumber);
+            return null;
+        });
+
+        // Return updated projects
+        const updatedProjects = await getAllProjects();
+        return NextResponse.json(updatedProjects);
+    } catch (error) {
+        console.error('Error deleting task:', error);
+        const errorMessage = error instanceof Error ? error.message : 'Failed to delete task';
+        return NextResponse.json(
+            { error: errorMessage },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/v1/projects/[projectId]/tasks/reorder/route.ts
+++ b/app/api/v1/projects/[projectId]/tasks/reorder/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAllProjects } from '@/lib/markdown';
+import { rewriteMarkdown } from '@/lib/markdown-updater';
+import { Task } from '@/lib/types';
+import {
+    validateProjectId,
+    validateFilePath,
+    withFileLock,
+} from '@/lib/security';
+
+interface RouteParams {
+    params: Promise<{
+        projectId: string;
+    }>;
+}
+
+/**
+ * PUT /api/v1/projects/[projectId]/tasks/reorder
+ * Reorders tasks within a project
+ */
+export async function PUT(request: NextRequest, { params }: RouteParams) {
+    try {
+        const { projectId } = await params;
+        const body = await request.json();
+        const { tasks } = body;
+
+        // Validate project ID
+        const projectIdValidation = validateProjectId(projectId);
+        if (!projectIdValidation.valid) {
+            return NextResponse.json(
+                { error: projectIdValidation.error },
+                { status: 400 }
+            );
+        }
+
+        // Validate tasks array
+        if (!tasks || !Array.isArray(tasks)) {
+            return NextResponse.json(
+                { error: 'Tasks array required for reordering' },
+                { status: 400 }
+            );
+        }
+
+        // Find project
+        const projects = await getAllProjects();
+        const project = projects.find((p) => p.id === projectId);
+
+        if (!project) {
+            return NextResponse.json(
+                { error: 'Project not found' },
+                { status: 404 }
+            );
+        }
+
+        // Validate file path
+        if (!validateFilePath(project.path)) {
+            return NextResponse.json(
+                { error: 'Invalid file path' },
+                { status: 400 }
+            );
+        }
+
+        // Use file locking
+        await withFileLock(project.path, async () => {
+            const updatedProject = { ...project, tasks: tasks as Task[] };
+            rewriteMarkdown(project.path, updatedProject);
+            return null;
+        });
+
+        // Return updated projects
+        const updatedProjects = await getAllProjects();
+        return NextResponse.json(updatedProjects);
+    } catch (error) {
+        console.error('Error reordering tasks:', error);
+        const errorMessage = error instanceof Error ? error.message : 'Failed to reorder tasks';
+        return NextResponse.json(
+            { error: errorMessage },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/v1/projects/[projectId]/tasks/route.ts
+++ b/app/api/v1/projects/[projectId]/tasks/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAllProjects } from '@/lib/markdown';
+import { addTask } from '@/lib/markdown-updater';
+import { TaskStatus } from '@/lib/types';
+import {
+    validateProjectId,
+    validateTaskContent,
+    validateTaskStatus,
+    validateDueDate,
+    validateLineNumber,
+    validateFilePath,
+    withFileLock,
+    sanitizeContent,
+} from '@/lib/security';
+
+interface RouteParams {
+    params: Promise<{
+        projectId: string;
+    }>;
+}
+
+/**
+ * POST /api/v1/projects/[projectId]/tasks
+ * Creates a new task in the project
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+    try {
+        const { projectId } = await params;
+        const body = await request.json();
+        const { content, status, dueDate, parentLineNumber } = body;
+
+        // Validate project ID
+        const projectIdValidation = validateProjectId(projectId);
+        if (!projectIdValidation.valid) {
+            return NextResponse.json(
+                { error: projectIdValidation.error },
+                { status: 400 }
+            );
+        }
+
+        // Find project
+        const projects = await getAllProjects();
+        const project = projects.find((p) => p.id === projectId);
+
+        if (!project) {
+            return NextResponse.json(
+                { error: 'Project not found' },
+                { status: 404 }
+            );
+        }
+
+        // Validate file path
+        if (!validateFilePath(project.path)) {
+            return NextResponse.json(
+                { error: 'Invalid file path' },
+                { status: 400 }
+            );
+        }
+
+        // Use file locking
+        const result = await withFileLock(project.path, async () => {
+            // Validate content
+            const contentValidation = validateTaskContent(content);
+            if (!contentValidation.valid) {
+                return { error: contentValidation.error, status: 400 };
+            }
+
+            // Validate status
+            const statusValidation = validateTaskStatus(status);
+            if (!statusValidation.valid) {
+                return { error: statusValidation.error, status: 400 };
+            }
+
+            // Validate due date
+            const dueDateValidation = validateDueDate(dueDate);
+            if (!dueDateValidation.valid) {
+                return { error: dueDateValidation.error, status: 400 };
+            }
+
+            // Validate parent line number if provided
+            if (parentLineNumber !== undefined) {
+                const lineValidation = validateLineNumber(parentLineNumber);
+                if (!lineValidation.valid) {
+                    return { error: lineValidation.error, status: 400 };
+                }
+            }
+
+            const sanitizedContent = sanitizeContent(content);
+            addTask(project.path, sanitizedContent, status as TaskStatus, dueDate, parentLineNumber);
+            return null;
+        });
+
+        // Check for validation errors
+        if (result && result.error) {
+            return NextResponse.json(
+                { error: result.error },
+                { status: result.status }
+            );
+        }
+
+        // Return updated projects
+        const updatedProjects = await getAllProjects();
+        return NextResponse.json(updatedProjects, { status: 201 });
+    } catch (error) {
+        console.error('Error adding task:', error);
+        const errorMessage = error instanceof Error ? error.message : 'Failed to add task';
+        return NextResponse.json(
+            { error: errorMessage },
+            { status: 500 }
+        );
+    }
+}

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { getAllProjects } from '@/lib/markdown';
+
+/**
+ * GET /api/v1/projects
+ * Returns all projects with their tasks
+ */
+export async function GET() {
+    try {
+        const projects = await getAllProjects();
+        return NextResponse.json(projects);
+    } catch (error) {
+        console.error('Error reading projects:', error);
+        return NextResponse.json(
+            { error: 'Failed to read projects' },
+            { status: 500 }
+        );
+    }
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -25,7 +25,7 @@ export class ApiError extends Error {
  * @throws {ApiValidationError} if response validation fails
  */
 export async function fetchProjects(): Promise<Project[]> {
-    const res = await fetch('/api/projects');
+    const res = await fetch('/api/v1/projects');
 
     if (!res.ok) {
         const errorData = await res.json().catch(() => ({ error: 'Unknown error' }));
@@ -48,12 +48,10 @@ export async function addTask(
     dueDate?: string,
     parentLineNumber?: number
 ): Promise<Project[]> {
-    const res = await fetch('/api/projects', {
+    const res = await fetch(`/api/v1/projects/${encodeURIComponent(projectId)}/tasks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-            action: 'add',
-            projectId,
             content,
             status,
             dueDate,
@@ -84,15 +82,10 @@ export async function updateTask(
         dueDate?: string;
     }
 ): Promise<Project[]> {
-    const res = await fetch('/api/projects', {
-        method: 'POST',
+    const res = await fetch(`/api/v1/projects/${encodeURIComponent(projectId)}/tasks/${lineNumber}`, {
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            action: 'updateTask',
-            projectId,
-            task: { lineNumber },
-            updates,
-        }),
+        body: JSON.stringify(updates),
     });
 
     if (!res.ok) {
@@ -113,14 +106,8 @@ export async function deleteTask(
     projectId: string,
     lineNumber: number
 ): Promise<Project[]> {
-    const res = await fetch('/api/projects', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            action: 'delete',
-            projectId,
-            task: { lineNumber },
-        }),
+    const res = await fetch(`/api/v1/projects/${encodeURIComponent(projectId)}/tasks/${lineNumber}`, {
+        method: 'DELETE',
     });
 
     if (!res.ok) {
@@ -141,14 +128,10 @@ export async function reorderTasks(
     projectId: string,
     tasks: Task[]
 ): Promise<Project[]> {
-    const res = await fetch('/api/projects', {
-        method: 'POST',
+    const res = await fetch(`/api/v1/projects/${encodeURIComponent(projectId)}/tasks/reorder`, {
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            action: 'reorder',
-            projectId,
-            tasks,
-        }),
+        body: JSON.stringify({ tasks }),
     });
 
     if (!res.ok) {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,432 @@
+openapi: 3.0.3
+info:
+  title: Markdown Todo API
+  description: |
+    RESTful API for managing task projects stored as Markdown files.
+    Tasks are organized in a hierarchical structure with support for subtasks,
+    due dates, and status tracking.
+  version: 1.0.0
+  contact:
+    name: API Support
+  license:
+    name: MIT
+
+servers:
+  - url: /api/v1
+    description: API v1
+
+tags:
+  - name: Projects
+    description: Project management operations
+  - name: Tasks
+    description: Task management operations
+
+paths:
+  /projects:
+    get:
+      tags:
+        - Projects
+      summary: Get all projects
+      description: Returns a list of all projects with their tasks
+      operationId: getProjects
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /projects/{projectId}:
+    get:
+      tags:
+        - Projects
+      summary: Get a project by ID
+      description: Returns a single project with all its tasks
+      operationId: getProjectById
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          description: The project ID
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+        '400':
+          description: Invalid project ID
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /projects/{projectId}/tasks:
+    post:
+      tags:
+        - Tasks
+      summary: Create a new task
+      description: Creates a new task in the specified project
+      operationId: createTask
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          description: The project ID
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTaskRequest'
+      responses:
+        '201':
+          description: Task created successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /projects/{projectId}/tasks/{lineNumber}:
+    put:
+      tags:
+        - Tasks
+      summary: Update a task
+      description: Updates an existing task's properties
+      operationId: updateTask
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          description: The project ID
+          schema:
+            type: string
+        - name: lineNumber
+          in: path
+          required: true
+          description: The task's line number in the markdown file
+          schema:
+            type: integer
+            minimum: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTaskRequest'
+      responses:
+        '200':
+          description: Task updated successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      tags:
+        - Tasks
+      summary: Delete a task
+      description: Deletes a task and all its subtasks
+      operationId: deleteTask
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          description: The project ID
+          schema:
+            type: string
+        - name: lineNumber
+          in: path
+          required: true
+          description: The task's line number in the markdown file
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: Task deleted successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /projects/{projectId}/tasks/reorder:
+    put:
+      tags:
+        - Tasks
+      summary: Reorder tasks
+      description: Reorders all tasks in a project
+      operationId: reorderTasks
+      parameters:
+        - name: projectId
+          in: path
+          required: true
+          description: The project ID
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReorderTasksRequest'
+      responses:
+        '200':
+          description: Tasks reordered successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Project not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+    TaskStatus:
+      type: string
+      enum:
+        - todo
+        - doing
+        - done
+      description: The status of a task
+
+    Task:
+      type: object
+      required:
+        - id
+        - content
+        - status
+        - subtasks
+        - lineNumber
+        - rawLine
+      properties:
+        id:
+          type: string
+          description: Unique task identifier (projectId-lineNumber)
+          example: "my-project-5"
+        content:
+          type: string
+          description: The task content text
+          example: "Buy groceries"
+        status:
+          $ref: '#/components/schemas/TaskStatus'
+        dueDate:
+          type: string
+          format: date
+          description: Optional due date in YYYY-MM-DD format
+          example: "2025-11-23"
+        subtasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Task'
+          description: Nested subtasks
+        parentId:
+          type: string
+          description: Reference to parent task ID (if nested)
+          example: "my-project-3"
+        parentContent:
+          type: string
+          description: Parent task content for display context
+          example: "Shopping list"
+        lineNumber:
+          type: integer
+          minimum: 1
+          description: Line number in the markdown file
+          example: 5
+        rawLine:
+          type: string
+          description: Original markdown line
+          example: "- [ ] Buy groceries #due:2025-11-23"
+
+    Project:
+      type: object
+      required:
+        - id
+        - title
+        - tasks
+        - path
+      properties:
+        id:
+          type: string
+          description: Unique project identifier
+          example: "my-project"
+        title:
+          type: string
+          description: Project title from H1 heading
+          example: "My Awesome Project"
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Task'
+          description: All tasks in the project
+        path:
+          type: string
+          description: File path to the markdown file
+          example: "data/my-project.md"
+
+    CreateTaskRequest:
+      type: object
+      required:
+        - content
+        - status
+      properties:
+        content:
+          type: string
+          description: The task content text
+          minLength: 1
+          maxLength: 500
+          example: "Buy groceries"
+        status:
+          $ref: '#/components/schemas/TaskStatus'
+        dueDate:
+          type: string
+          format: date
+          description: Optional due date in YYYY-MM-DD format
+          example: "2025-11-23"
+        parentLineNumber:
+          type: integer
+          minimum: 1
+          description: Line number of parent task (for creating subtasks)
+          example: 3
+
+    UpdateTaskRequest:
+      type: object
+      properties:
+        content:
+          type: string
+          description: Updated task content text
+          minLength: 1
+          maxLength: 500
+          example: "Buy groceries and vegetables"
+        status:
+          $ref: '#/components/schemas/TaskStatus'
+        dueDate:
+          type: string
+          format: date
+          description: Updated due date in YYYY-MM-DD format
+          example: "2025-11-25"
+
+    ReorderTasksRequest:
+      type: object
+      required:
+        - tasks
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Task'
+          description: Complete list of tasks in new order
+
+    Error:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: Error message
+          example: "Project not found"


### PR DESCRIPTION
- Add API versioning with /api/v1/ prefix
- Separate HTTP methods: GET for retrieval, POST for creation, PUT for updates, DELETE for removal
- Create RESTful endpoints:
  - GET /api/v1/projects - List all projects
  - GET /api/v1/projects/[projectId] - Get single project
  - POST /api/v1/projects/[projectId]/tasks - Create task
  - PUT /api/v1/projects/[projectId]/tasks/[lineNumber] - Update task
  - DELETE /api/v1/projects/[projectId]/tasks/[lineNumber] - Delete task
  - PUT /api/v1/projects/[projectId]/tasks/reorder - Reorder tasks
- Update frontend API client to use new RESTful endpoints
- Add OpenAPI 3.0 specification (openapi.yaml)

Closes #8