### PR TITLE
fix: Add displayName to MDView component

### DIFF
--- a/components/MDView.tsx
+++ b/components/MDView.tsx
@@ -142,3 +142,5 @@ export default function MDView({ projectId, onSaveSuccess, onError }: MDViewProp
         </div>
     );
 }
+
+MDView.displayName = 'MDView';


### PR DESCRIPTION
Resolves ESLint error requiring React component display name.