### PR TITLE
Remove email requirement from sign in

### DIFF
--- a/__tests__/api/v1/projects.test.ts
+++ b/__tests__/api/v1/projects.test.ts
@@ -11,7 +11,7 @@ import * as monitoring from '@/lib/monitoring';
 import * as Sentry from '@sentry/nextjs';
 
 type MockSession = {
-  user?: { id?: string; email?: string };
+  user?: { id?: string };
 };
 
 // Mock all dependencies
@@ -71,7 +71,7 @@ describe('API /api/v1/projects', () => {
 
     // Mock auth
     mockAuth.auth.mockResolvedValue({
-      user: { id: 'user123', email: 'test@example.com' },
+      user: { id: 'user123' },
     } as MockSession);
     mockAuth.getUserDataDir.mockReturnValue('/data/user123');
 
@@ -111,7 +111,7 @@ describe('API /api/v1/projects', () => {
 
     it('should return 401 when user ID is missing', async () => {
       mockAuth.auth.mockResolvedValue({
-        user: { email: 'test@example.com' },
+        user: {},
       } as MockSession);
 
       const response = await GET();
@@ -177,7 +177,7 @@ describe('API /api/v1/projects', () => {
 
     it('should use user-specific data directory', async () => {
       mockAuth.auth.mockResolvedValue({
-        user: { id: 'different-user', email: 'other@example.com' },
+        user: { id: 'different-user' },
       } as MockSession);
       mockAuth.getUserDataDir.mockReturnValue('/data/different-user');
 

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -5,7 +5,10 @@ import { z } from 'zod';
 
 const registerSchema = z.object({
     name: z.string().min(1, 'Name is required').max(100, 'Name is too long'),
-    email: z.string().email('Invalid email address'),
+    username: z.string().min(3, 'Username must be at least 3 characters').max(50, 'Username is too long').regex(
+        /^[a-zA-Z0-9_]+$/,
+        'Username can only contain letters, numbers, and underscores'
+    ),
     password: z
         .string()
         .min(8, 'Password must be at least 8 characters')
@@ -29,12 +32,12 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        const { name, email, password } = result.data;
+        const { name, username, password } = result.data;
 
         // Create user
-        const user = await createUser(name, email, password);
+        const user = await createUser(name, username, password);
 
-        securityLogger.info({ userId: user.id, email }, 'User registered successfully');
+        securityLogger.info({ userId: user.id, username }, 'User registered successfully');
 
         return NextResponse.json(
             {
@@ -42,15 +45,15 @@ export async function POST(request: NextRequest) {
                 user: {
                     id: user.id,
                     name: user.name,
-                    email: user.email,
+                    username: user.username,
                 },
             },
             { status: 201 }
         );
     } catch (error) {
-        if (error instanceof Error && error.message === 'User with this email already exists') {
+        if (error instanceof Error && error.message === 'User with this username already exists') {
             return NextResponse.json(
-                { error: 'User with this email already exists' },
+                { error: 'User with this username already exists' },
                 { status: 409 }
             );
         }

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
 export default function RegisterPage() {
     const router = useRouter();
     const [name, setName] = useState('');
-    const [email, setEmail] = useState('');
+    const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
     const [confirmPassword, setConfirmPassword] = useState('');
     const [isLoading, setIsLoading] = useState(false);
@@ -33,7 +33,7 @@ export default function RegisterPage() {
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                body: JSON.stringify({ name, email, password }),
+                body: JSON.stringify({ name, username, password }),
             });
 
             const data = await response.json();
@@ -103,19 +103,19 @@ export default function RegisterPage() {
                         </div>
 
                         <div>
-                            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
-                                Email address
+                            <label htmlFor="username" className="block text-sm font-medium text-gray-700">
+                                Username
                             </label>
                             <input
-                                id="email"
-                                name="email"
-                                type="email"
-                                autoComplete="email"
+                                id="username"
+                                name="username"
+                                type="text"
+                                autoComplete="username"
                                 required
-                                value={email}
-                                onChange={(e) => setEmail(e.target.value)}
+                                value={username}
+                                onChange={(e) => setUsername(e.target.value)}
                                 className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                                placeholder="you@example.com"
+                                placeholder="your_username"
                             />
                         </div>
 

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -12,7 +12,7 @@ function SignInContent() {
     const callbackUrl = searchParams?.get('callbackUrl') || '/';
     const error = searchParams?.get('error');
 
-    const [email, setEmail] = useState('');
+    const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [errorMessage, setErrorMessage] = useState('');
@@ -24,13 +24,13 @@ function SignInContent() {
 
         try {
             const result = await signIn('credentials', {
-                email,
+                username,
                 password,
                 redirect: false,
             });
 
             if (result?.error) {
-                setErrorMessage('Invalid email or password');
+                setErrorMessage('Invalid username or password');
             } else {
                 router.push(callbackUrl);
                 router.refresh();
@@ -71,19 +71,19 @@ function SignInContent() {
 
                     <div className="rounded-md shadow-sm -space-y-px">
                         <div>
-                            <label htmlFor="email" className="sr-only">
-                                Email address
+                            <label htmlFor="username" className="sr-only">
+                                Username
                             </label>
                             <input
-                                id="email"
-                                name="email"
-                                type="email"
-                                autoComplete="email"
+                                id="username"
+                                name="username"
+                                type="text"
+                                autoComplete="username"
                                 required
-                                value={email}
-                                onChange={(e) => setEmail(e.target.value)}
+                                value={username}
+                                onChange={(e) => setUsername(e.target.value)}
                                 className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
-                                placeholder="Email address"
+                                placeholder="Username"
                             />
                         </div>
                         <div>

--- a/components/UserMenu.tsx
+++ b/components/UserMenu.tsx
@@ -39,7 +39,7 @@ export default function UserMenu() {
             <div className="flex items-center space-x-2">
                 <User className="w-5 h-5 text-gray-500" />
                 <span className="text-sm font-medium text-gray-700">
-                    {session.user?.name || session.user?.email}
+                    {session.user?.name}
                 </span>
             </div>
             <button

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -5,7 +5,6 @@ declare module 'next-auth' {
         user: {
             id: string;
             name?: string | null;
-            email?: string | null;
             image?: string | null;
         };
     }
@@ -13,7 +12,6 @@ declare module 'next-auth' {
     interface User {
         id: string;
         name?: string | null;
-        email?: string | null;
     }
 }
 


### PR DESCRIPTION
- Update AppUser interface to use username instead of email
- Modify authentication functions to use username for lookups
- Update sign-in and registration forms to use username field
- Add username validation (alphanumeric and underscores only)
- Update NextAuth credentials provider configuration
- Remove email from TypeScript type definitions
- Update tests to reflect username-based authentication

This change simplifies authentication by using only a unique username instead of requiring an email address.