### PR TITLE
fix: Replace 'any' types with proper Task types and remove unused imp…

### DIFF
--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAllProjects } from '@/lib/markdown';
 import { updateMarkdown, addTask as addTaskFile, deleteTask as deleteTaskFile, updateTask as updateTaskFile, rewriteMarkdown, handleRecurringTask as handleRecurringTaskFile } from '@/lib/markdown-updater';
 import { addTask as addTaskDB, deleteTask as deleteTaskDB, updateTask as updateTaskDB, reorderTasks as reorderTasksDB, handleRecurringTask as handleRecurringTaskDB } from '@/lib/supabase-adapter';
-import { TaskStatus, RepeatFrequency } from '@/lib/types';
+import { TaskStatus, RepeatFrequency, Task } from '@/lib/types';
 import {
     validateProjectId,
     validateTaskContent,
@@ -183,7 +183,7 @@ export async function POST(request: NextRequest) {
                     if (updates?.status === 'done' && task.repeatFrequency) {
                         // For recurring tasks, we need the full task object with content
                         // Find the full task from the project
-                        const findFullTask = (tasks: any[]): any => {
+                        const findFullTask = (tasks: Task[]): Task | null => {
                             for (const t of tasks) {
                                 if (t.id === task.id) {
                                     return t;

--- a/app/api/v1/projects/[projectId]/raw/route.ts
+++ b/app/api/v1/projects/[projectId]/raw/route.ts
@@ -6,8 +6,8 @@ import { auth, getUserDataDir } from '@/lib/auth';
 import { getConfig } from '@/lib/config';
 import { renderMarkdown } from '@/lib/markdown-renderer';
 import { parseMarkdown } from '@/lib/markdown';
-import { getProject, updateTask, deleteTask, addTask, deleteAllTasksForProject } from '@/lib/supabase-adapter';
-import { getAllProjectsFromDir } from '@/lib/markdown';
+import { getProject, addTask, deleteAllTasksForProject } from '@/lib/supabase-adapter';
+import { Task } from '@/lib/types';
 
 interface RouteContext {
     params: Promise<{
@@ -171,7 +171,7 @@ export async function PUT(request: NextRequest, context: RouteContext) {
             // Track new task IDs for parent-child relationships
             const taskIdMap = new Map<string, string>(); // Maps old ID to new ID
 
-            async function createTasksRecursively(tasksToCreate: any[]): Promise<void> {
+            async function createTasksRecursively(tasksToCreate: Task[]): Promise<void> {
                 for (const task of tasksToCreate) {
                     // Get parent ID if this is a subtask
                     let newParentId: string | undefined;

--- a/app/api/v1/projects/[projectId]/tasks/route.ts
+++ b/app/api/v1/projects/[projectId]/tasks/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAllProjectsFromDir, getAllProjects } from '@/lib/markdown';
 import { addTask } from '@/lib/markdown-updater';
-import { TaskStatus, RepeatFrequency } from '@/lib/types';
+import { TaskStatus, RepeatFrequency, Task } from '@/lib/types';
 import * as supabaseAdapter from '@/lib/supabase-adapter';
 import {
     validateProjectId,
@@ -117,7 +117,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
             // Find parent task ID if parentLineNumber is provided
             let parentTaskId: string | undefined;
             if (parentLineNumber !== undefined) {
-                const findTaskByLineNumber = (tasks: any[]): any => {
+                const findTaskByLineNumber = (tasks: Task[]): Task | undefined => {
                     for (const task of tasks) {
                         if (task.lineNumber === parentLineNumber) return task;
                         if (task.subtasks) {


### PR DESCRIPTION
…orts

- Replace 'any' type with 'Task | undefined' in tasks/route.ts:120
- Replace 'any' type with 'Task[]' in raw/route.ts:174
- Replace 'any' type with 'Task | null' in projects/route.ts:186
- Remove unused imports (updateTask, deleteTask, getAllProjectsFromDir) from raw/route.ts
- Add Task type import to all affected files

This fixes all 9 linting errors that were causing the CI workflow to fail.