### PR TITLE
feat: Add hide/show completed tasks toggle

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -32,6 +32,36 @@
   background-clip: text;
 }
 
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.toggleButton {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.toggleButton:hover {
+  background: var(--accent-hover);
+  border-color: var(--primary);
+  transform: translateY(-1px);
+}
+
+.toggleButton:active {
+  transform: translateY(0);
+}
+
 .content {
   flex: 1;
   padding: 1rem 2rem 2rem;


### PR DESCRIPTION
Implements Issue #35 - Hide Done Task feature with the following:

- Add hideDoneTasks state with localStorage persistence
- Implement recursive filterDoneTasks function that:
  - Filters out done tasks while preserving task hierarchy
  - Keeps parent tasks visible if they have incomplete subtasks
  - Hides parent tasks only when all subtasks are done
- Add toggle button in header with Eye/EyeOff icons
- Apply filter to both TreeView and WeeklyView
- Settings persist across page reloads via localStorage

User can now click "Hide Done" button to focus on incomplete tasks, and "Show Done" to see all tasks. Follows Todoist-style UX pattern.