### PR TITLE
feat: Add project name inline editing functionality

### DIFF
--- a/app/api/v1/projects/[projectId]/route.ts
+++ b/app/api/v1/projects/[projectId]/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAllProjectsFromDir } from '@/lib/markdown';
-import { getProject } from '@/lib/supabase-adapter';
-import { validateProjectId } from '@/lib/security';
+import { getProject, updateProject } from '@/lib/supabase-adapter';
+import { validateProjectId, validateProjectTitle } from '@/lib/security';
 import { auth, getUserDataDir } from '@/lib/auth';
+import { updateProjectTitle } from '@/lib/markdown-updater';
 
 // Check if Supabase is configured
 const useSupabase = !!(
@@ -70,6 +71,79 @@ export async function GET(request: NextRequest, context: RouteContext) {
         console.error('Error reading project:', error);
         return NextResponse.json(
             { error: 'Failed to read project' },
+            { status: 500 }
+        );
+    }
+}
+
+/**
+ * PUT /api/v1/projects/[projectId]
+ * Updates a project's title
+ */
+export async function PUT(request: NextRequest, context: RouteContext) {
+    try {
+        const params = await context.params;
+        const projectId = params.projectId;
+
+        // Validate project ID
+        const projectIdValidation = validateProjectId(projectId);
+        if (!projectIdValidation.valid) {
+            return NextResponse.json(
+                { error: projectIdValidation.error },
+                { status: 400 }
+            );
+        }
+
+        // Get session and user ID
+        const session = await auth();
+        const userId = session?.user?.id;
+
+        if (!userId) {
+            return NextResponse.json(
+                { error: 'Unauthorized' },
+                { status: 401 }
+            );
+        }
+
+        // Parse request body
+        const body = await request.json();
+        const { title } = body;
+
+        // Validate title
+        const titleValidation = validateProjectTitle(title);
+        if (!titleValidation.valid) {
+            return NextResponse.json(
+                { error: titleValidation.error },
+                { status: 400 }
+            );
+        }
+
+        const trimmedTitle = title.trim();
+
+        if (useSupabase) {
+            // Update in Supabase
+            await updateProject(userId, projectId, trimmedTitle);
+        } else {
+            // Update in file-based storage
+            const dataDir = await getUserDataDir(userId);
+            const projects = await getAllProjectsFromDir(dataDir);
+            const project = projects.find((p) => p.id === projectId);
+
+            if (!project) {
+                return NextResponse.json(
+                    { error: 'Project not found' },
+                    { status: 404 }
+                );
+            }
+
+            updateProjectTitle(project.path, trimmedTitle);
+        }
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error('Error updating project:', error);
+        return NextResponse.json(
+            { error: 'Failed to update project' },
             { status: 500 }
         );
     }

--- a/components/Sidebar.module.css
+++ b/components/Sidebar.module.css
@@ -106,3 +106,25 @@
 .navItem svg {
     flex-shrink: 0;
 }
+
+.projectTitle {
+    flex: 1;
+    cursor: pointer;
+    user-select: none;
+}
+
+.editInput {
+    flex: 1;
+    background: var(--surface);
+    border: 1px solid var(--primary);
+    border-radius: var(--radius-sm, 4px);
+    color: var(--foreground);
+    font-size: 0.9rem;
+    padding: 0.25rem 0.5rem;
+    outline: none;
+}
+
+.editInput:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -57,6 +57,23 @@ export async function createProject(title: string): Promise<Project> {
 }
 
 /**
+ * Update a project's title
+ * @throws {ApiError} if the API request fails
+ */
+export async function updateProjectTitle(projectId: string, title: string): Promise<void> {
+    const res = await fetch(`/api/v1/projects/${encodeURIComponent(projectId)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title }),
+    });
+
+    if (!res.ok) {
+        const errorData = await res.json().catch(() => ({ error: 'Unknown error' }));
+        throw new ApiError(errorData.error || 'Failed to update project title', res.status);
+    }
+}
+
+/**
  * Add a new task
  * @throws {ApiError} if the API request fails
  * @throws {ApiValidationError} if response validation fails

--- a/lib/markdown-updater.ts
+++ b/lib/markdown-updater.ts
@@ -307,3 +307,33 @@ export function createProjectFile(filePath: string, title: string): void {
 
     fs.writeFileSync(filePath, content, config.fileEncoding);
 }
+
+/**
+ * Updates the project title (H1) in a markdown file
+ * @param filePath - Path to the markdown file
+ * @param newTitle - New project title
+ */
+export function updateProjectTitle(filePath: string, newTitle: string): void {
+    const config = getConfig();
+
+    // Read current content
+    const content = fs.readFileSync(filePath, config.fileEncoding);
+    const lines = content.split('\n');
+
+    // Find and update the first H1 heading
+    let updated = false;
+    const updatedLines = lines.map(line => {
+        if (!updated && line.startsWith('# ')) {
+            updated = true;
+            return `# ${newTitle}`;
+        }
+        return line;
+    });
+
+    // If no H1 found, add it at the beginning
+    if (!updated) {
+        updatedLines.unshift(`# ${newTitle}`);
+    }
+
+    fs.writeFileSync(filePath, updatedLines.join('\n'), config.fileEncoding);
+}

--- a/lib/supabase-adapter.ts
+++ b/lib/supabase-adapter.ts
@@ -157,6 +157,25 @@ export async function createProject(userId: string, projectId: string, title: st
 }
 
 /**
+ * Update a project's title
+ */
+export async function updateProject(userId: string, projectId: string, title: string): Promise<void> {
+    if (!supabaseAdmin) {
+        throw new Error('Supabase is not configured');
+    }
+
+    const { error } = await supabaseAdmin
+        .from('projects')
+        .update({ title })
+        .eq('id', projectId)
+        .eq('user_id', userId);
+
+    if (error) {
+        throw new Error(`Failed to update project: ${error.message}`);
+    }
+}
+
+/**
  * Update a task
  */
 export async function updateTask(


### PR DESCRIPTION
- Add PUT /api/v1/projects/[projectId] endpoint for updating project titles
- Add updateProjectTitle() to lib/api.ts for API calls
- Add updateProjectTitle() to lib/markdown-updater.ts for file-based updates
- Add updateProject() to lib/supabase-adapter.ts for database updates
- Implement inline editing in Sidebar with double-click to edit
- Add keyboard support (Enter to save, Escape to cancel)
- Add optimistic UI updates with rollback on error
- Add comprehensive test coverage for inline editing feature
- Update existing Sidebar tests to work with new structure (div instead of button)